### PR TITLE
fix/Security id type is string

### DIFF
--- a/src/main/java/com/hana/app/data/entity/Security.java
+++ b/src/main/java/com/hana/app/data/entity/Security.java
@@ -7,12 +7,17 @@ import lombok.*;
 @Table(name = "security")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Security extends BaseEntity {
     @Id
     @Column(name = "security_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
     @Column(nullable = false, name="security_name")
     private String name;
+
+    public static Security createSecurity(String code, String name) {
+        // 필요에 따라 추가적인 초기화 작업 수행
+        return new Security(code, name);
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #8 

## 🔑 Key Changes

1. Security pk type change : long ⨠ String

## 📢 To Reviewers
- Security(종목)의 primary key가 종목 코드이므로 String으로의 타입 수정이 불가피
