### PR TITLE
feature/system_admin_page_advanced

### DIFF
--- a/src/main/java/com/hana/app/service/ConsultService.java
+++ b/src/main/java/com/hana/app/service/ConsultService.java
@@ -6,11 +6,14 @@ import com.hana.app.repository.ConsultRepository;
 import com.hana.app.repository.PbRepository;
 import com.hana.app.repository.VipRepository;
 import com.hana.dto.request.ConsultRegisterDto;
+import com.hana.dto.response.ConsultAdminDto;
+import com.hana.dto.response.ConsultAdminItemDto;
 import com.hana.dto.response.ConsultSearchDto;
 import com.hana.dto.response.ConsultWebRTCRoomDto;
 import com.hana.exception.MeteorException;
 import com.hana.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.NotFound;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -36,6 +39,10 @@ public class ConsultService {
 
     public ConsultSearchDto searchConsultIsExist(Long pbId) {
         return new ConsultSearchDto(searchPbVipConsultIsExist(pbId));
+    }
+
+    public ConsultAdminDto extractAdminConsultData(){
+        return new ConsultAdminDto(extractAllConsultData());
     }
 
     private Consult makeConsult(ConsultRegisterDto consultRegisterDto) {
@@ -84,6 +91,22 @@ public class ConsultService {
             }
         } catch (MeteorException e) {
             throw new RuntimeException();
+        }
+
+        return list;
+    }
+
+    private List<ConsultAdminItemDto> extractAllConsultData() {
+        List<ConsultAdminItemDto> list = new ArrayList<>();
+
+        try {
+            for (Consult consult : consultRepository.findAll()) {
+                if (consult.getStatus() == BaseEntity.BaseState.ACTIVE) {
+                    list.add(ConsultAdminItemDto.from(consult));
+                }
+            }
+        } catch (MeteorException e) {
+            throw new NotFoundException(e.getErrorType());
         }
 
         return list;

--- a/src/main/java/com/hana/app/service/SecurityService.java
+++ b/src/main/java/com/hana/app/service/SecurityService.java
@@ -1,0 +1,38 @@
+package com.hana.app.service;
+
+import com.hana.app.data.entity.security.Security;
+import com.hana.app.repository.security.SecurityRepository;
+import com.hana.dto.response.SecurityDto;
+import com.hana.dto.response.SecurityItemDto;
+import com.hana.exception.MeteorException;
+import com.hana.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SecurityService {
+
+    final SecurityRepository securityRepository;
+
+    public SecurityDto extractAllSecurityInfo() {
+        return SecurityDto.from(allSecurities());
+    }
+
+    private List<SecurityItemDto> allSecurities() {
+        List<SecurityItemDto> list = new ArrayList<>();
+
+        try {
+            for (Security security : securityRepository.findAll()) {
+                list.add(SecurityItemDto.from(security));
+            }
+        } catch (MeteorException e) {
+            throw new NotFoundException(e.getErrorType());
+        }
+
+        return list;
+    }
+}

--- a/src/main/java/com/hana/controller/ConsultController.java
+++ b/src/main/java/com/hana/controller/ConsultController.java
@@ -2,6 +2,7 @@ package com.hana.controller;
 
 import com.hana.app.service.ConsultService;
 import com.hana.dto.request.ConsultRegisterDto;
+import com.hana.dto.response.ConsultAdminDto;
 import com.hana.dto.response.ConsultSearchDto;
 import com.hana.dto.response.ConsultWebRTCRoomDto;
 import com.hana.exception.InternalServerException;
@@ -53,5 +54,10 @@ public class ConsultController {
         }
 
         return consultSearchDto;
+    }
+
+    @GetMapping("/admin/allConsultInfo")
+    public ConsultAdminDto extractAllConsultInfo() {
+        return consultService.extractAdminConsultData();
     }
 }

--- a/src/main/java/com/hana/controller/SecurityController.java
+++ b/src/main/java/com/hana/controller/SecurityController.java
@@ -1,9 +1,21 @@
 package com.hana.controller;
 
-import org.springframework.stereotype.Controller;
+import com.hana.app.service.SecurityService;
+import com.hana.dto.response.SecurityDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequestMapping("/api/security")
+@RequiredArgsConstructor
 public class SecurityController {
+
+    final SecurityService securityService;
+
+    @GetMapping("/admin/allSecurities")
+    public SecurityDto extractAllSecurityData() {
+        return securityService.extractAllSecurityInfo();
+    }
 }

--- a/src/main/java/com/hana/dto/response/ConsultAdminDto.java
+++ b/src/main/java/com/hana/dto/response/ConsultAdminDto.java
@@ -1,0 +1,18 @@
+package com.hana.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ConsultAdminDto {
+    public List<ConsultAdminItemDto> consultAdminItemDtos;
+
+    public ConsultAdminDto(List<ConsultAdminItemDto> consultAdminItemDtos) {
+        this.consultAdminItemDtos = consultAdminItemDtos;
+    }
+
+    public static ConsultAdminDto from(List<ConsultAdminItemDto> consultAdminItemDtos) {
+        return new ConsultAdminDto(consultAdminItemDtos);
+    }
+}

--- a/src/main/java/com/hana/dto/response/ConsultAdminItemDto.java
+++ b/src/main/java/com/hana/dto/response/ConsultAdminItemDto.java
@@ -1,0 +1,27 @@
+package com.hana.dto.response;
+
+import com.hana.app.data.entity.BaseEntity;
+import com.hana.app.data.entity.Consult;
+import com.hana.app.data.entity.RiskType;
+import lombok.Getter;
+
+@Getter
+public class ConsultAdminItemDto {
+    private final Long id; // consult id
+    private final String vipName;
+    private final RiskType riskType;
+    private final String pbName;
+    private final BaseEntity.BaseState state;
+
+    public ConsultAdminItemDto(Consult consult) {
+        this.id = consult.getId();
+        this.vipName = consult.getVip().getUser().getName();
+        this.riskType = consult.getVip().getRiskType();
+        this.pbName = consult.getPb().getUser().getName();
+        this.state = consult.getStatus();
+    }
+
+    public static ConsultAdminItemDto from(Consult consult) {
+        return new ConsultAdminItemDto(consult);
+    }
+}

--- a/src/main/java/com/hana/dto/response/SecurityDto.java
+++ b/src/main/java/com/hana/dto/response/SecurityDto.java
@@ -1,0 +1,19 @@
+package com.hana.dto.response;
+
+import com.hana.app.data.entity.security.Security;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SecurityDto {
+    private final List<SecurityItemDto> list;
+
+    public SecurityDto(List<SecurityItemDto> list) {
+        this.list = list;
+    }
+
+    public static SecurityDto from(List<SecurityItemDto> list) {
+        return new SecurityDto(list);
+    }
+}

--- a/src/main/java/com/hana/dto/response/SecurityItemDto.java
+++ b/src/main/java/com/hana/dto/response/SecurityItemDto.java
@@ -1,0 +1,21 @@
+package com.hana.dto.response;
+
+import com.hana.app.data.entity.security.Security;
+import lombok.Getter;
+
+@Getter
+public class SecurityItemDto {
+    private final String id;
+    private final String name;
+    private final boolean isFund;
+
+    public SecurityItemDto(Security security) {
+        this.id = security.getId();
+        this.name = security.getName();
+        this.isFund = !security.getId().startsWith("K");
+    }
+
+    public static SecurityItemDto from(Security security){
+        return new SecurityItemDto(security);
+    }
+}

--- a/src/test/java/com/hana/portfolio/SelectFundGraphDataTests.java
+++ b/src/test/java/com/hana/portfolio/SelectFundGraphDataTests.java
@@ -8,16 +8,25 @@ import com.hana.controller.PortfolioController;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @Slf4j
-@RequiredArgsConstructor
 public class SelectFundGraphDataTests {
-    final PortfolioService portfolioService;
-    final PortfolioItemService portfolioItemService;
-    final SecurityPriceService securityPriceService;
-    private final FundSecurityService fundSecurityService;
+    @Autowired
+    PortfolioService portfolioService;
+
+    @Autowired
+    PortfolioItemService portfolioItemService;
+
+    @Autowired
+    SecurityPriceService securityPriceService;
+
+    @Autowired
+    FundSecurityService fundSecurityService;
+
+    @Autowired
     PortfolioController portfolioController;
 
     @Test


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #78 

## 🔑 Key Changes

1. 시스템 관리자 페이지 개선 작업

## 📢 To Reviewers
- /admin -> 비밀번호 입력 후 admin 페이지 입장
- /admin [system admin, default] -> 메인화면은 대시보드 형태로 여러 정보들 확인 가능 + ConsultAdminDto, ConsultAdminItemDto, SecurityDto, SecurityItemDto
- /admin [vip] -> vip 등록 화면(화면만)
- /admin [pb] -> pb 리스트 확인
- /admin [portfolio] -> 포트폴리오 구성상품 리스트 확인